### PR TITLE
Fix toast hook listener leak

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent accumulating listeners in `use-toast`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fe531a73c83249dbb17fe7682954d