### PR TITLE
Fix Supabase linter warnings

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -17,6 +17,18 @@ jwt_expiry = 3600
 jwt_secret = "super-secret-jwt-token-with-at-least-32-characters-long"
 enable_signup = true
 
+[auth.password]
+hibp_check_enabled = true
+
+[auth.mfa]
+enabled = true
+
+[auth.mfa.totp]
+enabled = true
+
+[auth.mfa.email]
+enabled = true
+
 [auth.email]
 enable_signup = true
 double_confirm_changes = true

--- a/supabase/migrations/20250525_set_search_path_and_extension.sql
+++ b/supabase/migrations/20250525_set_search_path_and_extension.sql
@@ -1,0 +1,16 @@
+-- Ensure extensions schema exists
+CREATE SCHEMA IF NOT EXISTS extensions;
+-- Move pg_net extension out of public schema
+ALTER EXTENSION IF EXISTS pg_net SET SCHEMA extensions;
+
+-- Set stable search_path for key functions
+ALTER FUNCTION IF EXISTS public.get_current_server_key() SET search_path = 'public, pg_temp';
+ALTER FUNCTION IF EXISTS public.get_federation_queue_stats() SET search_path = 'public, pg_temp';
+ALTER FUNCTION IF EXISTS public.update_actor_follower_count() SET search_path = 'public, pg_temp';
+ALTER FUNCTION IF EXISTS public.update_outgoing_follows_updated_at() SET search_path = 'public, pg_temp';
+ALTER FUNCTION IF EXISTS public.actor_id_to_partition_key(text) SET search_path = 'public, pg_temp';
+ALTER FUNCTION IF EXISTS public.set_federation_queue_partition_key(integer) SET search_path = 'public, pg_temp';
+ALTER FUNCTION IF EXISTS public.migrate_federation_queue_data() SET search_path = 'public, pg_temp';
+ALTER FUNCTION IF EXISTS public.create_follower_batches(uuid, jsonb, integer) SET search_path = 'public, pg_temp';
+ALTER FUNCTION IF EXISTS public.get_follower_batch_stats() SET search_path = 'public, pg_temp';
+ALTER FUNCTION IF EXISTS public.cleanup_expired_actor_cache() SET search_path = 'public, pg_temp';


### PR DESCRIPTION
## Summary
- configure password leak protection and MFA options in `config.toml`
- move `pg_net` extension to a dedicated schema and lock search_path on functions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684009f4db648324ae4801180b3d5f07