### PR TITLE
Implement auth endpoints with email confirmation

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -22,7 +22,7 @@ import { toast } from "sonner";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { Mail, Lock, ArrowRight } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
+import { signIn, signUp } from "@/services/authService";
 
 // Login form schema
 const loginSchema = z.object({
@@ -75,20 +75,11 @@ const Auth = () => {
     setIsLoading(true);
     
     try {
-      const { data, error } = await supabase.auth.signInWithPassword({
-        email: values.email,
-        password: values.password,
-      });
-      
-      if (error) {
-        toast.error(error.message);
-      } else {
-        toast.success("Welcome back!");
-        navigate("/");
-      }
-    } catch (error) {
-      toast.error("An unexpected error occurred");
-      console.error(error);
+      await signIn(values.email, values.password);
+      toast.success("Welcome back!");
+      navigate("/");
+    } catch (error: any) {
+      toast.error(error.message);
     } finally {
       setIsLoading(false);
     }
@@ -99,20 +90,11 @@ const Auth = () => {
     setIsLoading(true);
     
     try {
-      const { data, error } = await supabase.auth.signUp({
-        email: values.email,
-        password: values.password,
-      });
-      
-      if (error) {
-        toast.error(error.message);
-      } else {
-        toast.success("Account created! Please check your email to confirm your registration.");
-        navigate("/");
-      }
-    } catch (error) {
-      toast.error("An unexpected error occurred");
-      console.error(error);
+      await signUp(values.email, values.password);
+      toast.success("Account created! Please check your email to confirm.");
+      navigate("/");
+    } catch (error: any) {
+      toast.error(error.message);
     } finally {
       setIsLoading(false);
     }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,46 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export const signUp = async (email: string, password: string) => {
+  const response = await fetch("/functions/v1/auth-signup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password })
+  });
+  if (!response.ok) throw new Error("Signup failed");
+  return response.json();
+};
+
+export const confirmEmail = async (token: string) => {
+  const response = await fetch("/functions/v1/auth-confirm-email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token })
+  });
+  if (!response.ok) throw new Error("Confirmation failed");
+  return response.json();
+};
+
+export const signIn = async (email: string, password: string) => {
+  const response = await fetch("/functions/v1/auth-login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password })
+  });
+  if (!response.ok) throw new Error("Login failed");
+  const data = await response.json();
+  await supabase.auth.setSession({
+    access_token: data.access_token,
+    refresh_token: data.refresh_token
+  });
+  return data.user;
+};
+
+export const fetchMe = async () => {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return null;
+  const response = await fetch("/functions/v1/me", {
+    headers: { Authorization: `Bearer ${session.access_token}` }
+  });
+  if (!response.ok) return null;
+  return response.json();
+};

--- a/supabase/functions/auth-confirm-email/index.ts
+++ b/supabase/functions/auth-confirm-email/index.ts
@@ -1,0 +1,47 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { corsHeaders } from "../middleware/validate.ts";
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL") ?? "",
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+);
+
+const schema = z.object({ token: z.string().uuid() });
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const body = await req.json();
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    return new Response(JSON.stringify({ error: 'Validation error' }), { status: 422, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const { token } = result.data;
+  const { data, error } = await supabase
+    .from('email_verification_tokens')
+    .select('id, user_id, expires_at, used_at')
+    .eq('token', token)
+    .single();
+
+  if (error || !data) {
+    return new Response(JSON.stringify({ error: 'Invalid token' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  if (data.used_at || new Date(data.expires_at) < new Date()) {
+    return new Response(JSON.stringify({ error: 'Token expired' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  await supabase.auth.admin.updateUserById(data.user_id, { email_confirm: true });
+  await supabase
+    .from('email_verification_tokens')
+    .update({ used_at: new Date().toISOString() })
+    .eq('id', data.id);
+
+  return new Response(JSON.stringify({ success: true }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+});

--- a/supabase/functions/auth-login/index.ts
+++ b/supabase/functions/auth-login/index.ts
@@ -1,0 +1,72 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { corsHeaders } from "../middleware/validate.ts";
+
+const anonClient = createClient(
+  Deno.env.get("SUPABASE_URL") ?? "",
+  Deno.env.get("SUPABASE_ANON_KEY") ?? ""
+);
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6)
+});
+
+async function isRateLimited(ip: string) {
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+  );
+  const windowStart = new Date(Date.now() - 60_000).toISOString();
+  const { count } = await supabase
+    .from('auth_request_logs')
+    .select('*', { count: 'exact', head: true })
+    .eq('ip', ip)
+    .eq('endpoint', 'login')
+    .gte('timestamp', windowStart);
+  return (count ?? 0) >= 5;
+}
+
+async function logRequest(ip: string) {
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+  );
+  await supabase.from('auth_request_logs').insert({ ip, endpoint: 'login' });
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const ip = req.headers.get('x-forwarded-for') ?? req.headers.get('x-real-ip') ?? '';
+  if (await isRateLimited(ip)) {
+    return new Response(JSON.stringify({ error: 'Too many requests' }), { status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const body = await req.json();
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    return new Response(JSON.stringify({ error: 'Validation error' }), { status: 422, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const { email, password } = result.data;
+  const { data, error } = await anonClient.auth.signInWithPassword({ email, password });
+  await logRequest(ip);
+
+  if (error || !data.session) {
+    return new Response(JSON.stringify({ error: error?.message ?? 'Invalid credentials' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  return new Response(
+    JSON.stringify({
+      access_token: data.session.access_token,
+      refresh_token: data.session.refresh_token,
+      user: data.session.user
+    }),
+    { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+  );
+});

--- a/supabase/functions/auth-signup/index.ts
+++ b/supabase/functions/auth-signup/index.ts
@@ -1,0 +1,75 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+import { Resend } from "npm:resend@2.0.0";
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { corsHeaders } from "../middleware/validate.ts";
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL") ?? "",
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+);
+
+const resendApiKey = Deno.env.get("RESEND_API_KEY");
+const siteUrl = Deno.env.get("SITE_URL") ?? "http://localhost:3000";
+
+const signupSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6)
+});
+
+async function isRateLimited(ip: string) {
+  const windowStart = new Date(Date.now() - 60_000).toISOString();
+  const { count } = await supabase
+    .from('auth_request_logs')
+    .select('*', { count: 'exact', head: true })
+    .eq('ip', ip)
+    .eq('endpoint', 'signup')
+    .gte('timestamp', windowStart);
+  return (count ?? 0) >= 5;
+}
+
+async function logRequest(ip: string) {
+  await supabase.from('auth_request_logs').insert({ ip, endpoint: 'signup' });
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const ip = req.headers.get('x-forwarded-for') ?? req.headers.get('x-real-ip') ?? '';
+  if (await isRateLimited(ip)) {
+    return new Response(JSON.stringify({ error: 'Too many requests' }), { status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const body = await req.json();
+  const result = signupSchema.safeParse(body);
+  if (!result.success) {
+    return new Response(JSON.stringify({ error: 'Validation error' }), { status: 422, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const { email, password } = result.data;
+  const { data: user, error } = await supabase.auth.admin.createUser({ email, password, email_confirm: false });
+  if (error || !user) {
+    return new Response(JSON.stringify({ error: error?.message ?? 'Unable to create user' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const token = crypto.randomUUID();
+  const expires = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  await supabase.from('email_verification_tokens').insert({ user_id: user.id, token, expires_at: expires });
+  await logRequest(ip);
+
+  if (resendApiKey) {
+    const resend = new Resend(resendApiKey);
+    const confirmUrl = `${siteUrl}/confirm-email?token=${token}`;
+    await resend.emails.send({
+      from: 'noreply@bondy.local',
+      to: email,
+      subject: 'Confirm your Bondy account',
+      html: `<p>Please confirm your account by clicking <a href="${confirmUrl}">here</a>.</p>`
+    });
+  }
+
+  return new Response(JSON.stringify({ success: true }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+});

--- a/supabase/functions/me/index.ts
+++ b/supabase/functions/me/index.ts
@@ -1,0 +1,38 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+import { corsHeaders } from "../middleware/validate.ts";
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  if (req.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    { global: { headers: { Authorization: authHeader } } }
+  );
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', user.id)
+    .single();
+
+  return new Response(JSON.stringify({
+    id: user.id,
+    email: user.email,
+    profile
+  }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+});

--- a/supabase/functions/profile/index.ts
+++ b/supabase/functions/profile/index.ts
@@ -1,0 +1,57 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { corsHeaders } from "../middleware/validate.ts";
+
+const updateSchema = z.object({
+  fullname: z.string().optional(),
+  headline: z.string().optional(),
+  bio: z.string().optional(),
+  phone: z.string().optional(),
+  location: z.string().optional()
+});
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    { global: { headers: { Authorization: authHeader } } }
+  );
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  if (req.method === 'GET') {
+    const { data } = await supabase.from('profiles').select('*').eq('id', user.id).single();
+    return new Response(JSON.stringify(data), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  if (req.method === 'PUT') {
+    const body = await req.json();
+    const result = updateSchema.safeParse(body);
+    if (!result.success) {
+      return new Response(JSON.stringify({ error: 'Validation error' }), { status: 422, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+
+    const { error } = await supabase
+      .from('profiles')
+      .update({ ...result.data, updated_at: new Date().toISOString() })
+      .eq('id', user.id);
+
+    if (error) {
+      return new Response(JSON.stringify({ error: 'Update failed' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+
+    return new Response(JSON.stringify({ success: true }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
+  return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+});

--- a/supabase/migrations/20250526_email_verification.sql
+++ b/supabase/migrations/20250526_email_verification.sql
@@ -1,0 +1,15 @@
+-- Create table to store email verification tokens
+CREATE TABLE IF NOT EXISTS public.email_verification_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  token TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  used_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_user ON public.email_verification_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_token ON public.email_verification_tokens(token);
+
+ALTER TABLE public.email_verification_tokens ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "User can manage own tokens" ON public.email_verification_tokens
+  USING (auth.uid() = user_id);

--- a/supabase/migrations/20250527_auth_request_logs.sql
+++ b/supabase/migrations/20250527_auth_request_logs.sql
@@ -1,0 +1,9 @@
+-- Track auth endpoint requests for rate limiting
+CREATE TABLE IF NOT EXISTS public.auth_request_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ip TEXT NOT NULL,
+  endpoint TEXT NOT NULL,
+  timestamp TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_request_logs_ip_timestamp ON public.auth_request_logs(ip, timestamp);


### PR DESCRIPTION
## Summary
- add email confirmation and auth rate limiting migrations
- create serverless auth endpoints: signup, login, confirm-email, me, profile
- expose helper auth service and integrate into Auth page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68401180363883248ab909e348aeed8f