### PR TITLE
Use partitioned federation queue

### DIFF
--- a/scripts/migrate-federation-queue.js
+++ b/scripts/migrate-federation-queue.js
@@ -1,0 +1,21 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required');
+  process.exit(1);
+}
+
+const supabase = createClient(url, key);
+
+(async () => {
+  const { data, error } = await supabase.rpc('migrate_federation_queue_data');
+  if (error) {
+    console.error('Migration failed:', error.message);
+    process.exit(1);
+  }
+  console.log(`Migrated ${data} queue items`);
+})();
+

--- a/supabase/functions/federation/index.ts
+++ b/supabase/functions/federation/index.ts
@@ -23,9 +23,9 @@ serve(async (req) => {
   try {
     const { limit = 10 } = await req.json();
     
-    // Get pending federation queue items
+    // Get pending federation queue items from the partitioned view
     const { data: queueItems, error } = await supabaseClient
-      .from("federation_queue")
+      .from("federation_queue_partitioned")
       .select("*")
       .eq("status", "pending")
       .order("created_at", { ascending: true })
@@ -53,7 +53,7 @@ serve(async (req) => {
       try {
         // Mark as processing
         await supabaseClient
-          .from("federation_queue")
+          .from("federation_queue_partitioned")
           .update({ status: "processing" })
           .eq("id", item.id);
         
@@ -149,7 +149,7 @@ serve(async (req) => {
         
         // Mark as processed
         await supabaseClient
-          .from("federation_queue")
+          .from("federation_queue_partitioned")
           .update({ status: "processed" })
           .eq("id", item.id);
         
@@ -160,7 +160,7 @@ serve(async (req) => {
         
         // Mark as failed
         await supabaseClient
-          .from("federation_queue")
+          .from("federation_queue_partitioned")
           .update({ status: "failed" })
           .eq("id", item.id);
         

--- a/supabase/functions/following/index.ts
+++ b/supabase/functions/following/index.ts
@@ -98,7 +98,7 @@ serve(async (req) => {
     // For now, we'll look for Follow activities in the federation queue that were sent by this actor
     // In a more complete implementation, you might have a separate "following" table
     const { data: followingActivities, error: followingError } = await supabase
-      .from("federation_queue")
+      .from("federation_queue_partitioned")
       .select("activity")
       .eq("actor_id", actor.id)
       .eq("status", "processed")
@@ -124,7 +124,7 @@ serve(async (req) => {
 
     // Get total count of Follow activities for this actor
     const { count: totalFollowing, error: countError } = await supabase
-      .from("federation_queue")
+      .from("federation_queue_partitioned")
       .select("*", { count: "exact", head: true })
       .eq("actor_id", actor.id)
       .eq("status", "processed");


### PR DESCRIPTION
## Summary
- migrate Accept handling to the partitioned queue
- insert outgoing activities into the partitioned queue
- update worker and following list to use the new queue view
- add migration helper script for existing data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840396019bc83249fcacdbbba59ecba