### PR TITLE
Fix README info, add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jtensetti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 
+# 🌐 Bondy — a Fediverse Career Nexus
+
 A community-driven, federated job board designed for the open web.
 
 Built with ❤️ on [Lovable.dev](https://lovable.dev), **Fediverse Career Nexus** is robust enough to scale, but still open for improvement. It’s an experiment — and a mission — to make professional discovery possible across federated networks.
@@ -50,7 +52,7 @@ React (Vite) ──supabase-js──► Edge Functions (Deno)
 
 ```bash
 # 1. Clone & install
-pnpm i
+npm install
 
 # 2. Configure environment variables
 cp .env.example .env
@@ -58,7 +60,7 @@ cp .env.example .env
 
 # 3. Start Supabase + React app
 supabase start
-pnpm dev
+npm run dev
 
 # 4. Deploy Edge Functions (prod)
 supabase functions deploy \


### PR DESCRIPTION
## Summary
- restore project heading in README
- update install instructions to use `npm`
- add missing MIT license file

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684045b1e5c88324bf9ef6ab31a99230