### PR TITLE
Create logged-in home page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from "next-themes";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import SkipToContent from "./components/SkipToContent";
-import Index from "./pages/Index";
+import Home from "./pages/Home";
 import NotFound from "./pages/NotFound";
 import Profile from "./pages/Profile";
 import ProfileEdit from "./pages/ProfileEdit";
@@ -55,7 +55,7 @@ const App = () => (
           <SkipToContent />
           <div id="main-content" tabIndex={-1} className="outline-none">
             <Routes>
-              <Route path="/" element={<Index />} />
+              <Route path="/" element={<Home />} />
               <Route path="/auth/login" element={<Auth />} />
               <Route path="/auth/signup" element={<Auth />} />
               <Route path="/profile/:username" element={<Profile />} />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import Index from "./Index";
+import DashboardLayout from "@/components/DashboardLayout";
+import FederatedFeed from "@/components/FederatedFeed";
+
+const Home = () => {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      setIsAuthenticated(!!session);
+    };
+
+    checkAuth();
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_, session) => {
+      setIsAuthenticated(!!session);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  if (isAuthenticated === null) {
+    return null;
+  }
+
+  if (!isAuthenticated) {
+    return <Index />;
+  }
+
+  return (
+    <DashboardLayout showHeader={false}>
+      <div className="max-w-2xl mx-auto">
+        <FederatedFeed />
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- add a new Home page that checks authentication
- show feed when logged in
- update App routes to use the Home page

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68404ea87c508324b9a3503786f291b5