### PR TITLE
Enable post editing and fix creation logic

### DIFF
--- a/src/components/FederatedFeed.tsx
+++ b/src/components/FederatedFeed.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getFederatedFeed, type FederatedPost } from "@/services/federationService";
 import FederatedPostCard from "./FederatedPostCard";
+import PostEditDialog from "./PostEditDialog";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -16,6 +17,8 @@ interface FederatedFeedProps {
 export default function FederatedFeed({ limit = 10, className = "", sourceFilter = "all" }: FederatedFeedProps) {
   const [page, setPage] = useState<number>(1);
   const [allPosts, setAllPosts] = useState<FederatedPost[]>([]);
+  const [editingPost, setEditingPost] = useState<FederatedPost | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
   
   const { data: posts, isLoading, isFetching, error, refetch } = useQuery({
     queryKey: ['federatedFeed', page, limit],
@@ -50,8 +53,8 @@ export default function FederatedFeed({ limit = 10, className = "", sourceFilter
   };
 
   const handleEditPost = (post: FederatedPost) => {
-    // For now, just show a toast - you can implement edit modal later
-    toast.info("Edit functionality coming soon");
+    setEditingPost(post);
+    setEditOpen(true);
   };
 
   const handleDeletePost = (postId: string) => {
@@ -81,8 +84,8 @@ export default function FederatedFeed({ limit = 10, className = "", sourceFilter
       ) : allPosts.length > 0 ? (
         <>
           {allPosts.map((post, index) => (
-            <FederatedPostCard 
-              key={`${post.id}-${index}`} 
+            <FederatedPostCard
+              key={`${post.id}-${index}`}
               post={post}
               onEdit={handleEditPost}
               onDelete={handleDeletePost}
@@ -106,6 +109,12 @@ export default function FederatedFeed({ limit = 10, className = "", sourceFilter
               )}
             </Button>
           </div>
+          <PostEditDialog
+            open={editOpen}
+            onOpenChange={setEditOpen}
+            post={editingPost}
+            onUpdated={() => refetch()}
+          />
         </>
       ) : (
         <div className="text-center py-8">

--- a/src/components/FederatedPostCard.tsx
+++ b/src/components/FederatedPostCard.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { getProxiedMediaUrl } from "@/services/federationService";
 import { useAuth } from "@/contexts/AuthContext";
-import { supabase } from "@/integrations/supabase/client";
+import { deletePost } from "@/services/postService";
 import { toast } from "sonner";
 import type { FederatedPost } from "@/services/federationService";
 
@@ -150,16 +150,7 @@ export default function FederatedPostCard({ post, onEdit, onDelete }: FederatedP
     if (!onDelete) return;
     
     try {
-      const { error } = await supabase
-        .from('ap_objects')
-        .delete()
-        .eq('id', post.id);
-      
-      if (error) {
-        toast.error('Failed to delete post');
-        return;
-      }
-      
+      await deletePost(post.id);
       toast.success('Post deleted successfully');
       onDelete(post.id);
     } catch (error) {

--- a/src/components/PostEditDialog.tsx
+++ b/src/components/PostEditDialog.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { updatePost } from "@/services/postService";
+import type { FederatedPost } from "@/services/federationService";
+
+interface PostEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  post: FederatedPost | null;
+  onUpdated: () => void;
+}
+
+export default function PostEditDialog({ open, onOpenChange, post, onUpdated }: PostEditDialogProps) {
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (post) {
+      const text = (post.content.object?.content || post.content.content || "") as string;
+      setContent(text);
+    }
+  }, [post]);
+
+  const handleSave = async () => {
+    if (!post) return;
+    setLoading(true);
+    try {
+      await updatePost(post.id, { content });
+      toast.success("Post updated successfully!");
+      onUpdated();
+      onOpenChange(false);
+    } catch (err: any) {
+      toast.error(err.message || "Failed to update post");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Post</DialogTitle>
+        </DialogHeader>
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="min-h-[200px] mt-2"
+          disabled={loading}
+        />
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={loading || !content.trim()}>
+            {loading ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- fix actor URL when creating posts
- add update and delete helpers for posts
- add dialog UI for editing posts
- wire up edit/delete actions in feed components

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850165516488324aadc10095b9cb76c