### PR TITLE
Improve post service robustness and remove URL fallback

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,12 +2,12 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL =
-  import.meta.env.VITE_SUPABASE_URL ||
-  "https://tvvrdoklywxllcpzxdls.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY =
-  import.meta.env.VITE_SUPABASE_ANON_KEY ||
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InR2dnJkb2tseXd4bGxjcHp4ZGxzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY2ODQzNDEsImV4cCI6MjA2MjI2MDM0MX0.IDWfDP8pTNED7Owl_Yk2eG5c1DTnengwrAPUePHifPA";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
+  throw new Error('Supabase environment variables are not set');
+}
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/services/activityPubService.ts
+++ b/src/services/activityPubService.ts
@@ -35,7 +35,11 @@ export const createJobPostActivity = async (jobPost: any): Promise<ActivityPubAc
       return null;
     }
 
-    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://tvvrdoklywxllcpzxdls.supabase.co';
+    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    if (!supabaseUrl) {
+      toast.error('VITE_SUPABASE_URL not set');
+      return null;
+    }
     const actorUrl = `${supabaseUrl}/functions/v1/actor/${profile.username}`;
 
     // Create the Note/Article object for the job post

--- a/src/services/actorService.ts
+++ b/src/services/actorService.ts
@@ -124,7 +124,10 @@ export const createUserActor = async (userId: string): Promise<boolean> => {
     }
 
     // Get domain from environment
-    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://tvvrdoklywxllcpzxdls.supabase.co';
+    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    if (!supabaseUrl) {
+      throw new Error('VITE_SUPABASE_URL not set');
+    }
     const domain = new URL(supabaseUrl).hostname;
     
     // Create the ActivityPub actor object with the actual public key

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -131,7 +131,10 @@ export const createPost = async (postData: CreatePostData): Promise<Post | null>
       throw new Error('User profile not found');
     }
 
-    const supabaseUrl = 'https://tvvrdoklywxllcpzxdls.supabase.co';
+    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    if (!supabaseUrl) {
+      throw new Error('VITE_SUPABASE_URL not set');
+    }
     const actorUrl = `${supabaseUrl}/functions/v1/actor/${profile.username}`;
 
     let imageUrl: string | undefined;
@@ -237,7 +240,11 @@ const federatePost = async (activity: any, actorId: string) => {
     }
 
     // Send the activity to the outbox for federation
-    const response = await fetch(`https://tvvrdoklywxllcpzxdls.supabase.co/functions/v1/outbox/${profile.username}`, {
+    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    if (!supabaseUrl) {
+      throw new Error('VITE_SUPABASE_URL not set');
+    }
+    const response = await fetch(`${supabaseUrl}/functions/v1/outbox/${profile.username}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/activity+json',
@@ -324,8 +331,11 @@ export const updatePost = async (id: string, data: UpdatePostData): Promise<Post
       throw new Error('Post not found');
     }
 
-    // Create a mutable copy of the content
+    // Create a mutable copy of the content and ensure object exists
     const content = JSON.parse(JSON.stringify(existing.content)) as ActivityContent;
+    if (!content.object) {
+      content.object = { type: 'Note', content: '' } as ActivityContent['object'];
+    }
 
     if (data.content !== undefined) {
       content.object.content = data.content;

--- a/tests/postService.test.ts
+++ b/tests/postService.test.ts
@@ -1,0 +1,79 @@
+import { updatePost, deletePost } from '../src/services/postService';
+import { supabase } from '../src/integrations/supabase/client';
+
+type SupabaseFromReturn = {
+  select?: jest.Mock<any, any>;
+  update?: jest.Mock<any, any>;
+  delete?: jest.Mock<any, any>;
+  eq?: jest.Mock<any, any>;
+  single?: jest.Mock<any, any>;
+};
+
+jest.mock('../src/integrations/supabase/client', () => {
+  const fromMock = jest.fn();
+  const storageFromMock = jest.fn();
+  const auth = { getUser: jest.fn() };
+  return { supabase: { from: fromMock, storage: { from: storageFromMock }, auth } };
+});
+
+const mockedSupabase = supabase as unknown as {
+  from: jest.Mock<any, any>;
+  storage: { from: jest.Mock<any, any> };
+  auth: { getUser: jest.Mock<any, any> };
+};
+
+describe('postService', () => {
+  beforeEach(() => {
+    mockedSupabase.from.mockReset();
+    mockedSupabase.storage.from.mockReset();
+    mockedSupabase.auth.getUser.mockReset();
+  });
+
+  it('updates a post and uploads image', async () => {
+    mockedSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    const selectChain: SupabaseFromReturn = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: { content: { object: { type: 'Note', content: 'old' } } } })
+    };
+    const updateChain: SupabaseFromReturn = {
+      update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: { id: 'p1', published_at: 'now' } })
+    };
+
+    mockedSupabase.from
+      .mockReturnValueOnce(selectChain as any)
+      .mockReturnValueOnce(updateChain as any);
+
+    const uploadMock = jest.fn().mockResolvedValue({ error: null });
+    const getUrlMock = jest.fn().mockReturnValue({ data: { publicUrl: 'http://img' } });
+    mockedSupabase.storage.from.mockReturnValue({ upload: uploadMock, getPublicUrl: getUrlMock } as any);
+
+    const file = { name: 'pic.png', type: 'image/png' } as unknown as File;
+    const result = await updatePost('p1', { content: 'new', imageFile: file });
+
+    expect(result?.id).toBe('p1');
+    expect(result?.content).toBe('new');
+    expect(result?.imageUrl).toBe('http://img');
+    expect(selectChain.select).toHaveBeenCalledWith('content');
+    expect(uploadMock).toHaveBeenCalled();
+    expect(updateChain.update).toHaveBeenCalled();
+  });
+
+  it('deletes a post', async () => {
+    const deleteChain: SupabaseFromReturn = {
+      delete: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockResolvedValue({ error: null })
+    };
+    mockedSupabase.from.mockReturnValue(deleteChain as any);
+
+    const result = await deletePost('p1');
+
+    expect(result).toBe(true);
+    expect(deleteChain.delete).toHaveBeenCalled();
+    expect(deleteChain.eq).toHaveBeenCalledWith('id', 'p1');
+  });
+});


### PR DESCRIPTION
## Summary
- require Supabase env vars when creating client
- enforce env var checks before building actor URLs
- make `updatePost` tolerant of missing `object`
- switch federation calls to use env-supplied URL
- add unit tests for `updatePost` and `deletePost`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501e090d388324a319113218b16fdd