### PR TITLE
Add username display on posts and fix feed source detection

### DIFF
--- a/src/components/FederatedPostCard.tsx
+++ b/src/components/FederatedPostCard.tsx
@@ -104,6 +104,14 @@ export default function FederatedPostCard({ post, onEdit, onDelete }: FederatedP
     console.log('🌐 Remote actor name:', name, 'from actor:', actor);
     return name;
   };
+
+  // Extract username from profile or actor data
+  const getActorUsername = () => {
+    if (post.source === 'local') {
+      return post.profile?.username || post.actor?.preferredUsername || post.actor_name || '';
+    }
+    return post.actor?.preferredUsername || post.actor_name || '';
+  };
   
   // Get avatar URL with proxy for remote images
   const getAvatarUrl = () => {
@@ -284,6 +292,9 @@ export default function FederatedPostCard({ post, onEdit, onDelete }: FederatedP
             
             <div className="flex-1">
               <div className="font-semibold">{getActorName()}</div>
+              {getActorUsername() && (
+                <div className="text-xs text-muted-foreground">@{getActorUsername()}</div>
+              )}
               <div className="text-sm text-muted-foreground flex items-center gap-1">
                 <Globe size={14} />
                 <span>{post.source === 'local' ? 'Local' : 'Remote'}</span>

--- a/src/components/UserPostsList.tsx
+++ b/src/components/UserPostsList.tsx
@@ -1,0 +1,65 @@
+import { useQuery } from "@tanstack/react-query";
+import FederatedPostCard from "./FederatedPostCard";
+import { getUserPosts, type Post } from "@/services/postService";
+import { Loader2 } from "lucide-react";
+import { useEffect } from "react";
+
+interface UserPostsListProps {
+  userId?: string;
+  className?: string;
+}
+
+export default function UserPostsList({ userId, className = "" }: UserPostsListProps) {
+  const { data: posts, isLoading, error, refetch } = useQuery<Post[]>({
+    queryKey: ["userPosts", userId],
+    queryFn: () => getUserPosts(userId),
+  });
+
+  useEffect(() => {
+    // refetch when userId changes
+    refetch();
+  }, [userId, refetch]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 text-center text-red-500">Failed to load posts</div>
+    );
+  }
+
+  if (!posts || posts.length === 0) {
+    return <div className="p-4 text-center text-muted-foreground">No posts yet</div>;
+  }
+
+  return (
+    <div className={className}>
+      {posts.map((post) => (
+        <FederatedPostCard
+          key={post.id}
+          post={{
+            id: post.id,
+            content: { content: post.content },
+            created_at: post.created_at,
+            actor_name: post.author?.fullname || post.author?.username,
+            actor_avatar: post.author?.avatar_url,
+            user_id: post.user_id,
+            profile: {
+              fullname: post.author?.fullname,
+              username: post.author?.username,
+              avatar_url: post.author?.avatar_url,
+            },
+            source: 'local',
+            type: 'Note',
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -15,6 +15,7 @@ import { supabase } from "@/integrations/supabase/client";
 import FederationInfo from "@/components/FederationInfo";
 import { getUserProfileByUsername, getCurrentUserProfile, UserProfile } from "@/services/profileService";
 import { getUserConnections, NetworkConnection, sendConnectionRequest } from "@/services/connectionsService";
+import UserPostsList from "@/components/UserPostsList";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -274,6 +275,7 @@ const ProfilePage = () => {
               <TabsTrigger value="education">Education</TabsTrigger>
               <TabsTrigger value="skills">Skills</TabsTrigger>
               <TabsTrigger value="articles">Articles</TabsTrigger>
+              <TabsTrigger value="posts">Posts</TabsTrigger>
               <TabsTrigger value="connections">Connections</TabsTrigger>
             </TabsList>
             
@@ -405,6 +407,14 @@ const ProfilePage = () => {
                       </Button>
                     )}
                   </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value="posts">
+              <Card>
+                <CardContent className="pt-6">
+                  <UserPostsList userId={profile.id} />
                 </CardContent>
               </Card>
             </TabsContent>

--- a/src/services/federationService.ts
+++ b/src/services/federationService.ts
@@ -89,7 +89,7 @@ export const getFederatedFeed = async (limit: number = 20): Promise<FederatedPos
               avatar_url: profile.avatar_url
             }
           : undefined,
-        source: 'local' as const,
+        source: actor?.user_id ? 'local' as const : 'remote' as const,
         type: content?.type || 'Note'
       };
     });


### PR DESCRIPTION
## Summary
- show usernames on posts by enhancing FederatedPostCard
- include profile info when displaying a user's posts
- correctly classify local vs. remote posts when fetching the federated feed

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685144bb149c83249ec2df6b9af66a7f