### PR TITLE
Fix profile routing and show display names in posts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,14 @@ function App() {
                   }
                 />
                 <Route
+                  path="/profile/edit"
+                  element={
+                    <ProtectedRoute>
+                      <ProfileEdit />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
                   path="/profile"
                   element={
                     <ProtectedRoute>

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -197,15 +197,17 @@ export const getUserPosts = async (userId?: string): Promise<Post[]> => {
     // Get posts from ap_objects where the attributed actor belongs to the user
     const { data: posts, error } = await supabase
       .from('ap_objects')
-      .select(`
-        id,
-        content,
-        created_at,
-        actors!ap_objects_attributed_to_fkey (
+      .select(
+        `id, content, created_at, actors!ap_objects_attributed_to_fkey (
           user_id,
-          preferred_username
-        )
-      `)
+          preferred_username,
+          profiles (
+            fullname,
+            username,
+            avatar_url
+          )
+        )`
+      )
       .eq('actors.user_id', targetUserId)
       .order('published_at', { ascending: false });
 
@@ -227,8 +229,11 @@ export const getUserPosts = async (userId?: string): Promise<Post[]> => {
           image_url: note?.image,
           author: {
             username: (post.actors as any)?.preferred_username || 'Unknown',
-            avatar_url: undefined,
-            fullname: undefined,
+            fullname:
+              (post.actors as any)?.profiles?.fullname ||
+              (post.actors as any)?.preferred_username ||
+              'Unknown User',
+            avatar_url: (post.actors as any)?.profiles?.avatar_url,
           },
         };
       }) || []


### PR DESCRIPTION
## Summary
- add missing `/profile/edit` route so editing works
- include profile data when retrieving user posts

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685157579bc08324addefafdcb63f8ed