### PR TITLE
Align ActivityPub actor URLs with WebFinger responses

### DIFF
--- a/src/components/FederationInfo.tsx
+++ b/src/components/FederationInfo.tsx
@@ -128,7 +128,8 @@ export default function FederationInfo({ username, isOwnProfile }: FederationInf
   const isLocalUser = !actor?.home_instance || actor?.home_instance === 'local';
   const domain = isLocalUser ? getNoltoInstanceDomain() : actor.home_instance;
   const federatedHandle = `@${username}@${domain}`;
-  const remoteActorUri = `${window.location.origin}/actor/${username}`;
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL ?? window.location.origin;
+  const remoteActorUri = `${supabaseUrl}/functions/v1/actor/${username}`;
   const normalizedLookupInstance = lookupInstance
     .trim()
     .replace(/^https?:\/\//, "")

--- a/src/services/actorService.ts
+++ b/src/services/actorService.ts
@@ -62,7 +62,8 @@ export const generateRsaKeyPair = async (): Promise<{
 
 // Create a local actor object for ActivityPub
 export const createLocalActorObject = (profile: any, domain: string): LocalActor => {
-  const actorUrl = `https://${domain}/actor/${profile.username}`;
+  const supabaseUrl = `https://${domain}`;
+  const actorUrl = `${supabaseUrl}/functions/v1/actor/${profile.username}`;
   
   return {
     "@context": [
@@ -74,10 +75,10 @@ export const createLocalActorObject = (profile: any, domain: string): LocalActor
     preferredUsername: profile.username,
     name: profile.fullname || profile.username,
     summary: profile.bio || "",
-    inbox: `${actorUrl}/inbox`,
-    outbox: `${actorUrl}/outbox`,
-    followers: `${actorUrl}/followers`,
-    following: `${actorUrl}/following`,
+    inbox: `${supabaseUrl}/functions/v1/inbox/${profile.username}`,
+    outbox: `${supabaseUrl}/functions/v1/outbox/${profile.username}`,
+    followers: `${supabaseUrl}/functions/v1/followers/${profile.username}`,
+    following: `${supabaseUrl}/functions/v1/following/${profile.username}`,
     publicKey: {
       id: `${actorUrl}#main-key`,
       owner: actorUrl,

--- a/supabase/functions/actor/index.ts
+++ b/supabase/functions/actor/index.ts
@@ -86,13 +86,12 @@ serve(async (req) => {
     const { profile, actor } = result;
     const domain = url.hostname;
     const protocol = url.protocol;
-    const baseUrl = `${protocol}//${domain}`;
 
     // Create the actor object
     const actorObject = createActorObject(profile, actor, domain, protocol);
 
     // Cache the actor
-    await cacheActor(username, actorObject, baseUrl);
+    await cacheActor(username, actorObject);
     
     await logRequestMetrics(remoteHost, url.pathname, startTime, true, 200);
     return new Response(

--- a/supabase/functions/create-user-actor/index.ts
+++ b/supabase/functions/create-user-actor/index.ts
@@ -15,7 +15,8 @@ const supabaseClient = createClient(
 
 // Create local actor object
 function createLocalActorObject(profile: any, domain: string) {
-  const actorUrl = `https://${domain}/actor/${profile.username}`;
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? `https://${domain}`;
+  const actorUrl = `${supabaseUrl}/functions/v1/actor/${profile.username}`;
   
   return {
     "@context": [
@@ -27,10 +28,10 @@ function createLocalActorObject(profile: any, domain: string) {
     preferredUsername: profile.username,
     name: profile.fullname || profile.username,
     summary: profile.bio || "",
-    inbox: `${actorUrl}/inbox`,
-    outbox: `${actorUrl}/outbox`,
-    followers: `${actorUrl}/followers`,
-    following: `${actorUrl}/following`,
+    inbox: `${supabaseUrl}/functions/v1/inbox/${profile.username}`,
+    outbox: `${supabaseUrl}/functions/v1/outbox/${profile.username}`,
+    followers: `${supabaseUrl}/functions/v1/followers/${profile.username}`,
+    following: `${supabaseUrl}/functions/v1/following/${profile.username}`,
     publicKey: {
       id: `${actorUrl}#main-key`,
       owner: actorUrl,

--- a/supabase/functions/webfinger/index.ts
+++ b/supabase/functions/webfinger/index.ts
@@ -49,7 +49,8 @@ async function logRequestMetrics(
 
 // Create local actor object on-demand
 async function createLocalActorObject(profile: any, domain: string) {
-  const actorUrl = `https://${domain}/actor/${profile.username}`;
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? `https://${domain}`;
+  const actorUrl = `${supabaseUrl}/functions/v1/actor/${profile.username}`;
   
   // Try to get the actual public key from the actors table
   let publicKeyPem = "";
@@ -73,10 +74,10 @@ async function createLocalActorObject(profile: any, domain: string) {
     preferredUsername: profile.username,
     name: profile.fullname || profile.username,
     summary: profile.bio || "",
-    inbox: `${actorUrl}/inbox`,
-    outbox: `${actorUrl}/outbox`,
-    followers: `${actorUrl}/followers`,
-    following: `${actorUrl}/following`,
+    inbox: `${supabaseUrl}/functions/v1/inbox/${profile.username}`,
+    outbox: `${supabaseUrl}/functions/v1/outbox/${profile.username}`,
+    followers: `${supabaseUrl}/functions/v1/followers/${profile.username}`,
+    following: `${supabaseUrl}/functions/v1/following/${profile.username}`,
     publicKey: {
       id: `${actorUrl}#main-key`,
       owner: actorUrl,
@@ -305,7 +306,8 @@ serve(async (req) => {
       );
     }
 
-    const actorId = `https://${currentDomain}/actor/${profile.username}`;
+    const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? `https://${currentDomain}`;
+    const actorId = `${supabaseUrl}/functions/v1/actor/${profile.username}`;
     
     // Try to get actor from cache first
     let { data: cachedActor, error: cacheError } = await supabaseClient


### PR DESCRIPTION
### Motivation
- Local users signed up on the instance were not consistently discoverable because ActivityPub actor IDs and related endpoints were constructed with mixed base URLs (e.g. `/actor/...` vs the canonical Supabase `functions/v1/actor/...`), causing WebFinger and caches to mismatch when other instances tried to resolve `@user@nolto.social`.

### Description
- Normalize actor `id` to the canonical `SUPABASE_URL/functions/v1/actor/{username}` when building ActivityPub actor objects by reading `Deno.env.get("SUPABASE_URL")` and using it as the base for `id`, `publicKey` and collection URLs in `supabase/functions/actor/utils.ts` and related places.
- Update `inbox`, `outbox`, `followers`, `following`, `endpoints.sharedInbox`, and collection URLs to use the `functions/v1/*` endpoints across the codebase, including `supabase/functions/webfinger/index.ts`, `supabase/functions/create-user-actor/index.ts`, `supabase/functions/export-user-data/index.ts`, and `src/services/actorService.ts`.
- Change caching to consistently use the actor's canonical `actorObject.id` (remove the `baseUrl` parameter from `cacheActor`) so KV and database cache entries align with WebFinger-produced URLs.
- Sync frontend and export code to reference the canonical actor endpoints by updating `src/components/FederationInfo.tsx` and export payload construction to use the same `functions/v1` actor/inbox/outbox URLs.

### Testing
- No automated tests were executed against these changes in this rollout.  
- Existing unit test `supabase/tests/actor_utils.test.ts` remains present but was not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c399d1ec832481c4cc4624c14ba6)