### PR TITLE
Implement WebFinger responses for local discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Nolto implements the ActivityPub protocol for federation with other Fediverse in
 - `/actor/:username/followers` — Followers collection
 - `/actor/:username/following` — Following collection
 
+### WebFinger test calls
+- ✅ `/.well-known/webfinger?resource=acct:alice@nolto.social`
+- ❌ `/.well-known/webfinger?resource=acct:not-a-user@nolto.social` (should return 404)
+- ❌ `/.well-known/webfinger?resource=mailto:alice@nolto.social` (should return 400)
+- ❌ `/.well-known/webfinger?resource=acct:alice@otherdomain.tld` (should return 400)
+
 ### Supported Activities
 - **Create** — Posts, articles
 - **Follow** / **Accept** / **Reject** — Follow relationships


### PR DESCRIPTION
### Motivation
- Make WebFinger discovery on nolto.social compatible with Mastodon by returning correct JRD responses and actor links. 
- Ensure the endpoint uses the actual request host/protocol (honors forwarded host/proto) so resource domain checks work behind proxies.
- Avoid leaking internal IDs and provide a short cache policy and permissive CORS for federated clients.

### Description
- Add `Cache-Control: public, max-age=300` header and include it in successful/error responses to provide a reasonable cache policy.
- Add helper functions `getRequestHost` and `getRequestProtocol` to respect `x-forwarded-host`/`x-forwarded-proto` and build a `baseUrl` used for actor/profile URLs.
- Enforce `acct:username@domain` parsing with a stricter regexp and return 400 when the resource domain does not match this instance, removing remote-domain fetching from this function so the endpoint only serves local discovery.
- Use the computed `baseUrl` to build ActivityPub actor URLs and profile HTML URLs, update `createLocalActorObject` to accept `baseUrl`, and include both `rel: "self" (application/activity+json)` and `rel: "http://webfinger.net/rel/profile-page" (text/html)` links in the returned JRD object.
- Persist WebFinger responses in Deno KV (`KV`) with an expire time and return `Content-Type: application/jrd+json` for successful responses and `application/json` for errors; keep `Access-Control-Allow-Origin: *` CORS header.
- Document example WebFinger test calls in `README.md` under the Federation Guide.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c96502008324aae6af1d5ea13134)