### PR TITLE
feat: Implement Webfinger proxy via Cloudflare Worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.dev.vars

--- a/supabase/functions/cloudflare/cloudflare-worker.ts
+++ b/supabase/functions/cloudflare/cloudflare-worker.ts
@@ -1,0 +1,35 @@
+export default {
+  /**
+   * The fetch handler is the entry point for the worker.
+   * @param request The incoming request.
+   * @param env An object containing environment variables and secrets.
+   * @param ctx The execution context.
+   * @returns A Response object.
+   */
+
+  async fetch(
+    request: Request,
+    env: { SUPABASE_FUNCTION_URL: string },
+  ): Promise<Response> {
+    const url = new URL(request.url);
+
+    // We only care about requests to this specific path.
+    const WEBGER_PATH = "/.well-known/webfinger";
+
+    if (url.pathname === WEBGER_PATH) {
+      // The destination URL is stored as a secret.
+      const destinationUrl = new URL(env.SUPABASE_FUNCTION_URL);
+
+      // Preserve the original query string.
+      destinationUrl.search = url.search;
+
+      console.log(`Proxying request to: ${destinationUrl.toString()}`);
+
+      // Fetch the Supabase function and return its response directly to the client.
+      return fetch(destinationUrl.toString());
+    }
+
+    // If the path doesn't match, this worker shouldn't handle it.
+    return new Response("Path Not Found", { status: 404 });
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "webfinger-proxy-worker" # You can choose a different name if you like
+main = "supabase/functions/cloudflare/cloudflare-worker.ts"
+compatibility_date = "2024-01-01" # This date ensures consistent behavior


### PR DESCRIPTION
Setting up the cloudflare-worker 

- Calls to cloudflare server were made with
  1. wrangler CLI 
  2. curl requests after starting up the server 

```
~/projects/fediverse-career-nexus main* 1m 8s                                                                            03:37:06 PM
❯ wrangler dev

 ⛅️ wrangler 4.61.0
───────────────────
Using vars defined in .dev.vars
Your Worker has access to the following bindings:
Binding                                     Resource                  Mode
env.SUPABASE_FUNCTION_URL ("(hidden)")      Environment Variable      local

╭──────────────────────────────────────────────────────────────────────╮
│  [b] open a browser [d] open devtools [c] clear console [x] to exit  │
╰──────────────────────────────────────────────────────────────────────╯
⎔ Starting local server...
[wrangler:info] Ready on http://localhost:8787
Proxying request to: https://anknmcmqljejabxbeohv.supabase.co/functions/v1/webfinger?resource=acct:test@example.com
[wrangler:info] GET /.well-known/webfinger 400 Bad Request (1767ms)
Proxying request to: https://anknmcmqljejabxbeohv.supabase.co/functions/v1/webfinger?resource=acct:test@example.com
[wrangler:info] GET /.well-known/webfinger 400 Bad Request (934ms)
Proxying request to: https://anknmcmqljejabxbeohv.supabase.co/functions/v1/webfinger?resource=acct:test@nolto.social
[wrangler:info] GET /.well-known/webfinger 404 Not Found (1042ms)
Proxying request to: https://anknmcmqljejabxbeohv.supabase.co/functions/v1/webfinger?resource=acct:giancarlo@nolto.social
[wrangler:info] GET /.well-known/webfinger 200 OK (1985ms)
```

